### PR TITLE
Update Dockerfile to an available Ubuntu release - "Vivid"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:utopic
+FROM ubuntu:vivid
 
 # Setup NodeSource Official PPA
 RUN apt-get update && \


### PR DESCRIPTION
Pervious Ubuntu version is no longer available which caused "docker build" to fail. This change updated the base image to Ubuntu Vivid that is supported by node.